### PR TITLE
Make launching work

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
         "sqlite3": "^5.1.6"
     },
     "name": "pasma",
-    "type": "module",
-    "main": "dist/index.js",
+    "type": "commonjs",
+    "main": "dist/main.js",
     "scripts": {
         "build-css": "npx tailwindcss -i ./client/input.css -o ./public/output.css --watch",
         "build-back": "tsc",


### PR DESCRIPTION
Typescript compiles to CommonJS, which must be selected in order to run Jest tests and our compiled backend. Take note of this change when making tests.

This shouldn't be an issue with the frontend because of the way React works, and it shouldn't be an issue for the backend due to the compilation step from Typescript. It might be an issue for Jest, though. Keep this in mind, as you will be required to use `require` statements instead of `import`. 