### PR TITLE
Hotfix: Move around database object to work towards correct mocking and testing

### DIFF
--- a/server/api/getProfilePicture.ts
+++ b/server/api/getProfilePicture.ts
@@ -1,5 +1,4 @@
-import { db } from '../main';
-import { isPost, isUser } from '../database';
+import { db } from '../database';
 import { Request, Response } from 'express';
 
 export function dbProfilePicture (req: Request, res: Response) {

--- a/server/api/login.ts
+++ b/server/api/login.ts
@@ -3,8 +3,7 @@
 import crypto from "crypto";
 import { addSession } from "../types/Session";
 import { Request, Response } from "express";
-import { isUser } from "../database"
-import { db } from "../main"
+import { db, isUser } from "../database"
 
 /**
  * Logs in a user and stores the state, given that the username and password are correct.
@@ -27,6 +26,7 @@ export function login(req: Request, res: Response) {
         db.get(`select * from Users where username = "${req.body.username}"`, function (err, user) {
             if (err) {
                 res.status(500).send(`Server Error: ${err}`);
+                return;
             }
 
             if (typeof user === "undefined" || user === null) {
@@ -46,7 +46,6 @@ export function login(req: Request, res: Response) {
                 }            
             }
         });
-
     } else {
         res.status(400).send("Error: Request body was not able to be transformed into JSON.");
         return;

--- a/server/database.ts
+++ b/server/database.ts
@@ -41,18 +41,18 @@ export function isPost(x: any): x is Post {
  */
 export function initDB(dbFile: string): Database {
     // open database "db.sqlite". create if it does not exist
-    const db = new Database(dbFile);
+    const newDB = new Database(dbFile);
 
     // create tables for database if they do not exist.
-    db.serialize(() => {
-        db.run(`CREATE TABLE if not exists "Users" (
+    newDB.serialize(() => {
+        newDB.run(`CREATE TABLE if not exists "Users" (
             Username TEXT PRIMARY KEY, 
             Password TEXT NOT NULL, 
             Salt BLOB, 
             ProfilePicture TEXT
         );`);
 
-        db.run(`CREATE TABLE if not exists "Posts" (
+        newDB.run(`CREATE TABLE if not exists "Posts" (
             ID TEXT PRIMARY KEY, 
             Username TEXT, 
             Content TEXT, 
@@ -62,13 +62,24 @@ export function initDB(dbFile: string): Database {
         );`);
         
         // insert test user (for now)
-        const salt = crypto.randomBytes(16);
-        const testPassword = crypto.pbkdf2Sync("password", salt, 1000, 64, "sha512").toString('hex'); 
-        db.run(`INSERT OR IGNORE INTO Users(Username, Password, Salt)
-            VALUES(?, ?, ?);
-        `, 
-        ["alice", testPassword, salt]);
+        let salt: Buffer = crypto.randomBytes(16);
+        let testPassword: Buffer = crypto.pbkdf2Sync("alice_password", salt, 1000, 64, "sha512"); 
+        
+        // In a testing environment, testPassword will be undefined...
+        // ...unless you console.log it (and then it will become undefined after the fact...)
+        if (testPassword) {
+            newDB.run(`INSERT OR IGNORE INTO Users(Username, Password, Salt)
+                VALUES(?, ?, ?);
+            `, 
+            ["alice", testPassword.toString("hex"), salt]);
+        }
     });
 
-    return db;
+    return newDB;
 }
+
+/**
+ * The database.
+ * @see database#initDB 
+ */
+export const db = initDB("./db.sqlite");

--- a/server/main.ts
+++ b/server/main.ts
@@ -1,17 +1,9 @@
 // Here is the file which will act as the launching point for our Bun backend.
 
 import express, { Express, NextFunction, Request, Response } from 'express';
-import { Database } from 'sqlite3';
-import { initDB } from './database';
-
 import { login } from "./api/login";
 import { dbProfilePicture } from './api/getProfilePicture';
 
-/**
- * The database.
- * @see database#initDB 
- */
-export const db : Database = initDB("./db.sqlite");
 
 /**
  * The actual app. Set request handlers to this object.

--- a/test/utils/types.ts
+++ b/test/utils/types.ts
@@ -1,0 +1,41 @@
+// Due to Typescript being bad at inferring types, we need to have 
+// some type definitions for some commonly-used method signatures.
+// This gets especially bad when mocking, and is some times necessary.
+// Here are just a few. Feel free to add your own, 
+// alongside a JSDoc describing which function it's supposed to be for.
+
+import { Statement } from "sqlite3";
+import { BinaryLike } from "crypto";
+
+export type TypedArray =
+  | Int8Array
+  | Uint8Array
+  | Uint8ClampedArray
+  | Int16Array
+  | Uint16Array
+  | Int32Array
+  | Uint32Array
+  | Float32Array
+  | Float64Array;
+
+/**
+ * Type for `db.get`. 
+ * 
+ * Doesn't work *perfectly* well since the output is something we can't actually
+ * match the `this` output.
+ */
+export type DBGetType = (
+    sql: string, 
+    callback?: (this: Statement, err: Error | null, row: any) => void
+) => any;
+
+/**
+ * Type for `Crypto.pbkdf2Sync`.
+ */
+export type PBKDF2SyncType = (
+    password: BinaryLike,
+    salt: BinaryLike,
+    iterations: number,
+    keylen: number,
+    digest: string
+) => Buffer;


### PR DESCRIPTION
Testing still isn't *fully* working, though. This'll just implement database locational changes for the time being (which is more important so that when we get back to this later it won't be all out of place).

Mocking objects is weird, so moving the database object into the database file (which we'll already be mocking) will allow us to mock the entire file instead of mocking just the database object (which doesn't quite work). This will allow us to mock specific database functions (like `db.get`).

There's still an issue where the endpoint never completes, but this should be moving in the correct direction towards getting testing actually working.